### PR TITLE
Return ErrNotFound if value is not found

### DIFF
--- a/gitconfig.go
+++ b/gitconfig.go
@@ -20,12 +20,14 @@ package gitconfig
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io/ioutil"
 	"os/exec"
 	"strings"
 	"syscall"
 )
+
+var ErrNotFound = errors.New("the key was not found")
 
 // Global extracts configuration value from `$HOME/.gitconfig` file or `$GIT_CONFIG`.
 func Global(key string) (string, error) {
@@ -66,7 +68,7 @@ func execGitConfig(args ...string) (string, error) {
 	if exitError, ok := err.(*exec.ExitError); ok {
 		if waitStatus, ok := exitError.Sys().(syscall.WaitStatus); ok {
 			if waitStatus.ExitStatus() == 1 {
-				return "", fmt.Errorf("the key was not found")
+				return "", ErrNotFound
 			}
 		}
 		return "", err

--- a/gitconfig_test.go
+++ b/gitconfig_test.go
@@ -30,6 +30,7 @@ func TestGlobal(t *testing.T) {
 
 	nothing, err := Local("nothing.return")
 	Expect(err).To(HaveOccurred())
+	Expect(err == ErrNotFound).To(BeTrue(), "expect ErrNotFound, but got %V", err)
 	Expect(nothing).To(Equal(""))
 }
 
@@ -46,6 +47,7 @@ func TestLocal(t *testing.T) {
 
 	nothing, err := Local("nothing.return")
 	Expect(err).To(HaveOccurred())
+	Expect(err == ErrNotFound).To(BeTrue(), "expect ErrNotFound, but got %V", err)
 	Expect(nothing).To(Equal(""))
 }
 


### PR DESCRIPTION
I modified functions to return the fixed error `ErrNotFound`.
It let us know whether `git config` unexpectedly aborted or just entry not found as following:

``` go
v, err := gitconfig.Global("diff.tool")
if err == gitconfig.ErrNotFound {
    println("diff.tool not configured, use /usr/bin/diff command")
    v = "/usr/bin/diff"
}
```
