### PR TITLE
Add GithubUser getter

### DIFF
--- a/gitconfig.go
+++ b/gitconfig.go
@@ -44,6 +44,12 @@ func Local(key string) (string, error) {
 	return execGitConfig("--local", key)
 }
 
+// GithubUser extracts github.user name from `Entire gitconfig`
+// This is same as Entire("github.user")
+func GithubUser() (string, error) {
+	return Entire("github.user")
+}
+
 // Username extracts git user name from `Entire gitconfig`.
 // This is same as Entire("user.name")
 func Username() (string, error) {

--- a/gitconfig_test.go
+++ b/gitconfig_test.go
@@ -13,6 +13,8 @@ func TestGlobal(t *testing.T) {
 [user]
     name  = deeeet
     email = deeeet@example.com
+[github]
+    user = ghdeeeet
 `)
 	defer reset()
 
@@ -24,6 +26,10 @@ func TestGlobal(t *testing.T) {
 	email, err := Global("user.email")
 	Expect(err).NotTo(HaveOccurred())
 	Expect(email).To(Equal("deeeet@example.com"))
+
+	githubuser, err := Global("github.user")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(githubuser).To(Equal("ghdeeeet"))
 
 	nothing, err := Local("nothing.return")
 	Expect(err).To(HaveOccurred())


### PR DESCRIPTION
Support git configuration where user.name is the users full name and github.user is their github username.

Once merged this method can be used by `ghr` to conditionally select `github.user` as the username if it is set in `~/.gitconfig` rather than the users full name.