### PR TITLE
Add type ErrNotFound

### DIFF
--- a/gitconfig.go
+++ b/gitconfig.go
@@ -28,6 +28,14 @@ import (
 	"syscall"
 )
 
+type ErrNotFound struct {
+	Key string
+}
+
+func (e *ErrNotFound) Error() string {
+	return fmt.Sprintf("the key `%s` is not found", e.Key)
+}
+
 // Entire extracts configuration value from `$HOME/.gitconfig` file ,
 // `$GIT_CONFIG`, /etc/gitconfig or include.path files.
 func Entire(key string) (string, error) {
@@ -96,7 +104,7 @@ func execGitConfig(args ...string) (string, error) {
 	if exitError, ok := err.(*exec.ExitError); ok {
 		if waitStatus, ok := exitError.Sys().(syscall.WaitStatus); ok {
 			if waitStatus.ExitStatus() == 1 {
-				return "", fmt.Errorf("the key `%s` is not found", args[len(args)-1])
+				return "", &ErrNotFound{Key: args[len(args)-1]}
 			}
 		}
 		return "", err


### PR DESCRIPTION
Hello!

The commit [Return more concreate message · tcnksm/go-gitconfig@afc0b61](https://github.com/tcnksm/go-gitconfig/commit/afc0b61fff5302a89121f1510a37e5bfe9a6f5a5) removed a constant error value `ErrNotFound`. Due to the change, it is impossible for us to know an error is because of lack of entry or not (without comparision of ".Error()" in bad manner).

So, I suggest to return an instance of defined error type instead of `fmt.Errorf`.

Usage:

```
v, err := gitconfig.Global("diff.tool")
if _, ok := err.(*gitconfig.ErrNotFound); ok {
    println("diff.tool not configured, use /usr/bin/diff command")
    v = "/usr/bin/diff"
}
```

Thanks!
