### PR TITLE
Isolate test environment

### DIFF
--- a/gitconfig_test.go
+++ b/gitconfig_test.go
@@ -39,11 +39,12 @@ func TestGlobal(t *testing.T) {
 func TestEntire(t *testing.T) {
 	RegisterTestingT(t)
 
-	includeFilePath := includeGitConfigFile(`
+	includeFilePath, resetInclude := includeGitConfigFile(`
 [user]
     name  = deeeet
     email = deeeet@example.com
 	`)
+	defer resetInclude()
 
 	content := fmt.Sprintf(`
 [include]


### PR DESCRIPTION
The test environment is not fully isolated. An email or username set in the project's own git repo, which is located in the current working directory, interfered with `TestUsername()` or `TestEmail()`, respectively. This patch isolates the environment.
